### PR TITLE
🙏 makes the GO button unnecessary if all required params are set

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -56,11 +56,21 @@ export class AppComponent implements OnInit, OnDestroy {
       this.apiKey = params.get('sdkKey');
       this.baseUrl = params.get('baseUrl');
       this.featureFlagKey = params.get('featureFlagKey');
+      let hideControls = params.get('hideControls');
 
-      if (!this.featureFlagKey) { this.featureFlagKey = 'isAwesomeFeatureEnabled'; }
+      if (!this.featureFlagKey) { this.featureFlagKey = ''; }
       this.apiKeyFormGroup = this.formBuilder.group({ apiKey: [this.apiKey, Validators.required] });
       this.featureFlagKeyFormGroup = this.formBuilder.group({ featureFlagKey: ['', Validators.required] });
       this.userCountFormGroup = this.formBuilder.group({ userCount: [20, Validators.required] });
+
+      if(this.apiKey && this.apiKey.length > 0) {
+        // at this point, we have everything to try to init the client
+        this.initializeConfigCatClient();
+        if(this.featureFlagKey && this.featureFlagKey.length > 0 && hideControls === "true") {
+          // it's very likely the app is configured through the url, and the user wants to use it that way
+          this.showHeader = false;
+        }
+      }
 
       this.loading = false;
 
@@ -150,6 +160,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   initializeFeatureFlagKey() {
     if (!this.featureFlagKeyFormGroup.valid) {
+      this.featureFlagKeyInitialized = false;
       return;
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -60,13 +60,14 @@ export class AppComponent implements OnInit, OnDestroy {
 
       if (!this.featureFlagKey) { this.featureFlagKey = ''; }
       this.apiKeyFormGroup = this.formBuilder.group({ apiKey: [this.apiKey, Validators.required] });
-      this.featureFlagKeyFormGroup = this.formBuilder.group({ featureFlagKey: ['', Validators.required] });
+      this.featureFlagKeyFormGroup = this.formBuilder.group({ featureFlagKey: [this.featureFlagKey, Validators.required] });
       this.userCountFormGroup = this.formBuilder.group({ userCount: [20, Validators.required] });
 
-      if(this.apiKey && this.apiKey.length > 0) {
+      if(this.apiKey) {
         // at this point, we have everything to try to init the client
         this.initializeConfigCatClient();
-        if(this.featureFlagKey && this.featureFlagKey.length > 0 && hideControls === "true") {
+        let x = this.featureFlagKeyInitialized;
+        if(this.featureFlagKey && hideControls === "true") {
           // it's very likely the app is configured through the url, and the user wants to use it that way
           this.showHeader = false;
         }


### PR DESCRIPTION
### Describe the purpose of your pull request

- initializes the ConfigCat client on startup if both the sdkKey and the featureFlagKey parameters are set in the URL
- additionally, hides the header UI with the user's controls if the hideControls=true URL param is there too

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
